### PR TITLE
adds DeploySpinner and RetractSpinner commands

### DIFF
--- a/src/main/java/frc/robot/commands/DeploySpinner.java
+++ b/src/main/java/frc/robot/commands/DeploySpinner.java
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;  
+import frc.robot.subsystems.Spinner;
+import edu.wpi.first.wpilibj.DoubleSolenoid;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.TestingDashboard;
+
+public class DeploySpinner extends CommandBase {
+  Spinner m_piston;
+  boolean m_finished = false;
+  
+  public DeploySpinner() {
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(Spinner.getInstance());
+    m_piston = Spinner.getInstance();
+  }
+
+  public static void registerWithTestingDashboard() {
+    Spinner spinner = Spinner.getInstance();
+    DeploySpinner cmd = new DeploySpinner();
+    TestingDashboard.getInstance().registerCommand(spinner, "Basic", cmd);
+  }
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_piston.getValve().set(DoubleSolenoid.Value.kForward);
+    m_finished = false;
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    if (m_piston.getValve().get() == DoubleSolenoid.Value.kForward) {
+      m_piston.getValve().set(DoubleSolenoid.Value.kOff);
+      m_finished = true;
+    }  
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    m_piston.getValve().set(DoubleSolenoid.Value.kOff); 
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return m_finished;
+  }
+}

--- a/src/main/java/frc/robot/commands/DeploySpinner.java
+++ b/src/main/java/frc/robot/commands/DeploySpinner.java
@@ -11,17 +11,18 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.Spinner;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.TestingDashboard;
 
 public class DeploySpinner extends CommandBase {
-  Spinner m_piston;
+  Spinner m_spinner;
   boolean m_finished = false;
+  DoubleSolenoid m_piston;
   
   public DeploySpinner() {
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(Spinner.getInstance());
-    m_piston = Spinner.getInstance();
+    m_spinner = Spinner.getInstance();
+    m_piston = m_spinner.getPiston();
   }
 
   public static void registerWithTestingDashboard() {
@@ -32,15 +33,15 @@ public class DeploySpinner extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    m_piston.getValve().set(DoubleSolenoid.Value.kForward);
+    m_piston.set(DoubleSolenoid.Value.kForward);
     m_finished = false;
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    if (m_piston.getValve().get() == DoubleSolenoid.Value.kForward) {
-      m_piston.getValve().set(DoubleSolenoid.Value.kOff);
+    if (m_piston.get() == DoubleSolenoid.Value.kForward) {
+      m_piston.set(DoubleSolenoid.Value.kOff);
       m_finished = true;
     }  
   }
@@ -48,7 +49,7 @@ public class DeploySpinner extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_piston.getValve().set(DoubleSolenoid.Value.kOff); 
+    m_piston.set(DoubleSolenoid.Value.kOff); 
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/RetractSpinner.java
+++ b/src/main/java/frc/robot/commands/RetractSpinner.java
@@ -11,17 +11,18 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import frc.robot.subsystems.Spinner;
 
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.TestingDashboard;
 
 public class RetractSpinner extends CommandBase {
-  Spinner m_piston;
+  Spinner m_spinner;
   boolean m_finished = false;
+  DoubleSolenoid m_piston;
   
   public RetractSpinner() {
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(Spinner.getInstance());
-    m_piston = Spinner.getInstance();
+    m_spinner = Spinner.getInstance();
+    m_piston = m_spinner.getPiston();
   }
 
   public static void registerWithTestingDashboard() {
@@ -33,15 +34,15 @@ public class RetractSpinner extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    m_piston.getValve().set(DoubleSolenoid.Value.kReverse);
+    m_piston.set(DoubleSolenoid.Value.kReverse);
     m_finished = false;
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    if (m_piston.getValve().get() == DoubleSolenoid.Value.kReverse) {
-      m_piston.getValve().set(DoubleSolenoid.Value.kOff);
+    if (m_piston.get() == DoubleSolenoid.Value.kReverse) {
+      m_piston.set(DoubleSolenoid.Value.kOff);
       m_finished = true;
     }
   }
@@ -49,7 +50,7 @@ public class RetractSpinner extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_piston.getValve().set(DoubleSolenoid.Value.kOff); 
+    m_piston.set(DoubleSolenoid.Value.kOff); 
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/RetractSpinner.java
+++ b/src/main/java/frc/robot/commands/RetractSpinner.java
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj.DoubleSolenoid;
+import frc.robot.subsystems.Spinner;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.TestingDashboard;
+
+public class RetractSpinner extends CommandBase {
+  Spinner m_piston;
+  boolean m_finished = false;
+  
+  public RetractSpinner() {
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(Spinner.getInstance());
+    m_piston = Spinner.getInstance();
+  }
+
+  public static void registerWithTestingDashboard() {
+    Spinner spinner = Spinner.getInstance();
+    RetractSpinner cmd = new RetractSpinner();
+    TestingDashboard.getInstance().registerCommand(spinner, "Basic", cmd);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_piston.getValve().set(DoubleSolenoid.Value.kReverse);
+    m_finished = false;
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    if (m_piston.getValve().get() == DoubleSolenoid.Value.kReverse) {
+      m_piston.getValve().set(DoubleSolenoid.Value.kOff);
+      m_finished = true;
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    m_piston.getValve().set(DoubleSolenoid.Value.kOff); 
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/RetractSpinner.java
+++ b/src/main/java/frc/robot/commands/RetractSpinner.java
@@ -56,6 +56,6 @@ public class RetractSpinner extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return false;
+    return m_finished;
   }
 }

--- a/src/main/java/frc/robot/subsystems/Spinner.java
+++ b/src/main/java/frc/robot/subsystems/Spinner.java
@@ -80,6 +80,9 @@ public class Spinner extends SubsystemBase {
     return colorString;
   }
 
+  public DoubleSolenoid getValve() {
+		return m_piston;
+	}
   @Override
   public void periodic() {
     // This method will be called once per scheduler run

--- a/src/main/java/frc/robot/subsystems/Spinner.java
+++ b/src/main/java/frc/robot/subsystems/Spinner.java
@@ -80,9 +80,10 @@ public class Spinner extends SubsystemBase {
     return colorString;
   }
 
-  public DoubleSolenoid getValve() {
+  public DoubleSolenoid getPiston() {
 		return m_piston;
-	}
+  }
+  
   @Override
   public void periodic() {
     // This method will be called once per scheduler run


### PR DESCRIPTION
This commit adds the DeploySpinner and RetractSpinner commands. The DeploySpinner command extends the piston that is used to push the motor and color sensor up. The RetractSpinner command retracts the same piston.